### PR TITLE
chore: expose Grafana Agent HTTP route

### DIFF
--- a/k8s/kkweon-okteto/grafana-agent.yaml
+++ b/k8s/kkweon-okteto/grafana-agent.yaml
@@ -6,6 +6,7 @@ data:
   agent.yaml: |
     server:
       http_listen_port: 12345
+      http_path_prefix: /grafana-agent/
     prometheus:
       wal_directory: /tmp/grafana-agent-wal
       global:
@@ -42,22 +43,43 @@ data:
         target_config:
           sync_period: 10s
 ---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: grafana-agent
+  name: grafana-agent
+spec:
+  ports:
+    - name: http-metrics
+      port: 12345
+      targetPort: http-metrics
+  selector:
+    app: grafana-agent
+  type: ClusterIP
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  labels:
+    app: grafana-agent
   name: grafana-agent
   namespace: kkweon
 spec:
   minReadySeconds: 10
   replicas: 1
-  revisionHistoryLimit: 10
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+  revisionHistoryLimit: 5
   selector:
     matchLabels:
-      name: grafana-agent
+      app: grafana-agent
   template:
     metadata:
       labels:
-        name: grafana-agent
+        app: grafana-agent
     spec:
       containers:
         - args:

--- a/k8s/kkweon-okteto/grafana-agent.yaml
+++ b/k8s/kkweon-okteto/grafana-agent.yaml
@@ -1,0 +1,79 @@
+kind: ConfigMap
+metadata:
+  name: grafana-agent
+apiVersion: v1
+data:
+  agent.yaml: |
+    server:
+      http_listen_port: 12345
+    prometheus:
+      wal_directory: /tmp/grafana-agent-wal
+      global:
+        scrape_interval: 15s
+      configs:
+      - name: integrations
+        remote_write:
+        - url: https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push
+          basic_auth:
+            username: ${GRAFANA_KKWEON_USERNAME}
+            password: ${GRAFANA_KKWEON_PASSWORD}
+        scrape_configs:
+        - job_name: integrations/kubernetes/services
+          static_configs:
+            - targets:
+              - server:9093
+    integrations:
+      prometheus_remote_write:
+      - url: https://prometheus-blocks-prod-us-central1.grafana.net/api/prom/push
+        basic_auth:
+          username: ${GRAFANA_KKWEON_USERNAME}
+          password: ${GRAFANA_KKWEON_PASSWORD}
+
+    loki:
+      configs:
+      - name: integrations
+        clients:
+        - url: https://logs-prod-us-central1.grafana.net/api/prom/push
+          basic_auth:
+            username: ${GRAFANA_KKWEON_USERNAME}
+            password: ${GRAFANA_KKWEON_PASSWORD}
+        positions:
+          filename: /tmp/positions.yaml
+        target_config:
+          sync_period: 10s
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: grafana-agent
+  namespace: kkweon
+spec:
+  minReadySeconds: 10
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      name: grafana-agent
+  template:
+    metadata:
+      labels:
+        name: grafana-agent
+    spec:
+      containers:
+        - args:
+            - -config.file=/etc/agent/agent.yaml
+          command:
+            - /bin/agent
+          image: grafana/agent:v0.15.0
+          imagePullPolicy: IfNotPresent
+          name: agent
+          ports:
+            - containerPort: 12345
+              name: http-metrics
+          volumeMounts:
+            - mountPath: /etc/agent
+              name: grafana-agent
+      volumes:
+        - configMap:
+            name: grafana-agent
+          name: grafana-agent

--- a/k8s/kkweon-okteto/ingress.yaml
+++ b/k8s/kkweon-okteto/ingress.yaml
@@ -1,6 +1,27 @@
 kind: Ingress
 apiVersion: networking.k8s.io/v1
 metadata:
+  name: ingress-http
+  annotations:
+    kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    dev.okteto.com/generate-host: "true"
+spec:
+  rules:
+    - host: this-name-does-not-matter
+      http:
+        paths:
+          - path: /grafana-agent
+            pathType: Prefix
+            backend:
+              service:
+                name: grafana-agent
+                port:
+                  name: http-metrics
+---
+kind: Ingress
+apiVersion: networking.k8s.io/v1
+metadata:
   name: ingress
   annotations:
     kubernetes.io/ingress.class: "nginx"

--- a/k8s/kkweon-okteto/server.yaml
+++ b/k8s/kkweon-okteto/server.yaml
@@ -21,6 +21,10 @@ metadata:
   name: server
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: server

--- a/k8s/kkweon-okteto/server.yaml
+++ b/k8s/kkweon-okteto/server.yaml
@@ -12,10 +12,6 @@ spec:
       port: 9000
       protocol: TCP
       targetPort: grpc
-    - name: http-metrics
-      port: 9093
-      protocol: TCP
-      targetPort: http-metrics
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/okteto-pipeline.yaml
+++ b/okteto-pipeline.yaml
@@ -1,6 +1,6 @@
 deploy:
   - okteto build -t okteto.dev/codingpot-pr12er-server:${OKTETO_GIT_COMMIT} -f ./server/deploy/Dockerfile server
-  - envsubst < <(cat ./k8s/kkweon-okteto/*.yaml) | kubectl apply -f -
+  - for file in k8s/kkweon-okteto/*.yaml; do envsubst < $file | kubectl apply -f -; done
   - kubectl set image deployment server server=okteto.dev/codingpot-pr12er-server:${OKTETO_GIT_COMMIT}
   - kubectl rollout restart deployment grafana-agent
   - kubectl rollout status deployment server && kubectl rollout status deployment grafana-agent

--- a/okteto-pipeline.yaml
+++ b/okteto-pipeline.yaml
@@ -1,4 +1,6 @@
 deploy:
   - okteto build -t okteto.dev/codingpot-pr12er-server:${OKTETO_GIT_COMMIT} -f ./server/deploy/Dockerfile server
-  - kubectl apply -f ./k8s/kkweon-okteto
+  - envsubst < <(cat ./k8s/kkweon-okteto/*.yaml) | kubectl apply -f -
   - kubectl set image deployment server server=okteto.dev/codingpot-pr12er-server:${OKTETO_GIT_COMMIT}
+  - kubectl rollout restart deployment grafana-agent
+  - kubectl rollout status deployment server && kubectl rollout status deployment grafana-agent


### PR DESCRIPTION
# This PR depends on #47 

- Expose `/grafana-agent/metrics`

## Expose 하는 이유
- cronjob 으로 엔드포인트에 핑 꽂아서 깨우기 위해