### PR TITLE
chore(makefile): add help to list available make cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BIN_INSTALL_DIR := $$HOME/.local/bin
 BUF_VERSION := 0.43.2
 
 .PHONY: install
-install: install.buf
+install: install.buf ## install buf, protoc, go
 	curl -OL $(PROTOC_FULL_URL)
 	unzip -o $(PROTOC_FILE) -d $(BIN_INSTALL_DIR)/../
 	export PATH="$${PATH}:$(BIN_INSTALL_DIR)"
@@ -36,58 +36,64 @@ install: install.buf
 	pub global activate protoc_plugin
 
 .PHONY: install.go
-install.go:
+install.go: ## install go with dependencies
 	cd server && go mod download && grep _ ./cmd/tools/tools.go | cut -d' ' -f2 | sed 's/\r//' | xargs go install && go mod tidy
 
 .PHONY: install.buf
-install.buf:
+install.buf: ## install buf
 	mkdir -p "$(BIN_INSTALL_DIR)"
 	curl -sSL "https://github.com/bufbuild/buf/releases/download/v$(BUF_VERSION)/buf-$(shell uname -s)-$(shell uname -m)" -o "$(BIN_INSTALL_DIR)/buf"
 	chmod +x "$(BIN_INSTALL_DIR)/buf"
 
 .PHONY: uninstall.buf
-uninstall.buf:
+uninstall.buf: ## uninstall buf
 	rm -f $(BIN_INSTALL_DIR)/buf
 
 .PHONY: gen.all
-gen.all:
+gen.all: ## generate all
 	buf generate
 
 .PHONY: test
-test: test.go test.dart
+test: test.go test.dart ## test go and dart files
 
 .PHONY: test.dart
-test.dart: $(DART_MOCK_TARGETS)
+test.dart: $(DART_MOCK_TARGETS) ## test dart files
 	cd client && flutter analyze && flutter test
 
 $(DART_MOCK_TARGETS): $(DART_MOCK_SRCS)
 	cd client && flutter pub run build_runner build
 
 .PHONY: test.dart-e2e
-test.dart-e2e:
+test.dart-e2e: ## e2e test for dart files
 	cd client && flutter drive --target=test_driver/app.dart
 
 .PHONY: format.dart
-format.dart:
+format.dart: ## format dart files
 	cd client && flutter format .
 	make gen.all
 
 .PHONY: test.go
-test.go: lint.go
+test.go: ## test go files
+	$(MAKE) lint.go
 	cd server && go test ./...
 
 .PHONY: format.go
-format.go:
+format.go: ## format go files
 	cd server && gci -w . && gofumpt -w -s .
 	# regenerate as generated files should not be edited.
 	make gen.all
 
 .PHONY: lint.go
-lint.go:
+lint.go: ## lint go files
 	cd server && golangci-lint run
 
 .PHONY: clean
-clean:
+clean: ## clean up proto generated files and mocks
 	rm -rf ./client/lib/protos
 	rm -rf ./server/pkg/pr12er/*.pb.go
 	find ./client/test/ -name *.mocks.dart -delete
+
+.PHONY: help
+help: ## show available commands
+	@printf "make commands:\n\n"
+	@grep -E '^[a-zA-Z_.]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\t\033[1m%-30s\033[0m %s\n", $$1, $$2}'

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.DEFAULT_GOAL := gen.all
+.DEFAULT_GOAL := help
 
 PROTOC_VERSION := 3.17.2
 PROTOC_RELEASE := https://github.com/protocolbuffers/protobuf/releases

--- a/Makefile
+++ b/Makefile
@@ -73,8 +73,7 @@ format.dart: ## format dart files
 	make gen.all
 
 .PHONY: test.go
-test.go: ## test go files
-	$(MAKE) lint.go
+test.go: lint.go ## test go files
 	cd server && go test ./...
 
 .PHONY: format.go

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ BIN_INSTALL_DIR := $$HOME/.local/bin
 BUF_VERSION := 0.43.2
 
 .PHONY: install
-install: install.buf ## install buf, protoc, go
+install: install.buf ## install buf, protoc, protoc-gen for Go & Dart
 	curl -OL $(PROTOC_FULL_URL)
 	unzip -o $(PROTOC_FILE) -d $(BIN_INSTALL_DIR)/../
 	export PATH="$${PATH}:$(BIN_INSTALL_DIR)"


### PR DESCRIPTION
## WHAT

- add a simpleomment for each make command
- and add help commend to list up all make commands

## WHY

- to show available make commands

## EXAMPLE

```bash
$ make help
```

<img width="1127" alt="Screenshot 2021-06-19 at 1 49 12" src="https://user-images.githubusercontent.com/21152231/122593775-1c6ab780-d0a1-11eb-8c5c-5f72fb41f1f8.png">

as default goal changed (7747f10), you can also do:

```bash
$ make
```

returns:

```bash
$ make
make commands:

	clean                          clean up proto generated files and mocks
	format.dart                    format dart files
	format.go                      format go files
	gen.all                        generate all
	help                           show available commands
	install.buf                    install buf
	install.go                     install go with dependencies
	install                        install buf, protoc, protoc-gen for Go & Dart
	lint.go                        lint go files
	test.dart                      test dart files
	test.go                        test go files
	test                           test go and dart files
	uninstall.buf                  uninstall buf
```
